### PR TITLE
Add textSpec' and primitives

### DIFF
--- a/src/Config/Schema/Docs.hs
+++ b/src/Config/Schema/Docs.hs
@@ -128,15 +128,16 @@ disjunction False xs =         hsep (intersperse "or" xs)
 valueDoc :: PrimValueSpec a -> DocBuilder Doc
 valueDoc w =
   case w of
-    TextSpec         -> pure "text"
-    NumberSpec       -> pure "number"
-    AtomSpec a       -> pure ("`" <> txt a <> "`")
-    AnyAtomSpec      -> pure "atom"
-    SectionsSpec l s -> sectionsDoc l s
-    NamedSpec    l s -> emitDoc l (valuesDoc False s)
-    CustomSpec l w'  -> (txt l                 <+>) <$> valuesDoc True w'
-    ListSpec ws      -> ("list of"             <+>) <$> valuesDoc True ws
-    AssocSpec ws     -> ("association list of" <+>) <$> valuesDoc True ws
+    TextSpec           -> pure "text"
+    SpecificTextSpec a -> pure ("\"" <> txt a <> "\"")
+    NumberSpec         -> pure "number"
+    AtomSpec a         -> pure ("`" <> txt a <> "`")
+    AnyAtomSpec        -> pure "atom"
+    SectionsSpec l s   -> sectionsDoc l s
+    NamedSpec    l s   -> emitDoc l (valuesDoc False s)
+    CustomSpec l w'    -> (txt l                 <+>) <$> valuesDoc True w'
+    ListSpec ws        -> ("list of"             <+>) <$> valuesDoc True ws
+    AssocSpec ws       -> ("association list of" <+>) <$> valuesDoc True ws
 
 
 -- | A writer-like type. A mapping of section names and documentation

--- a/src/Config/Schema/Load.hs
+++ b/src/Config/Schema/Load.hs
@@ -97,6 +97,9 @@ getValue1 v prim = withExcept (pure . PrimMismatch (describeSpec prim))
 -- | Match a primitive value specification against a single value.
 getValue2 :: Value p -> PrimValueSpec a -> Except (Problem p) a
 getValue2 (Text _ t)       TextSpec           = pure t
+getValue2 (Text _ a)       (SpecificTextSpec b)
+  | a == b = pure ()
+  | otherwise = throwE WrongText
 getValue2 (Number _ n)     NumberSpec         = pure n
 getValue2 (List _ xs)      (ListSpec w)       = getList w xs
 getValue2 (Atom _ b)       AnyAtomSpec        = pure (atomName b)

--- a/src/Config/Schema/Load/Error.hs
+++ b/src/Config/Schema/Load/Error.hs
@@ -86,6 +86,7 @@ data Problem p
   | TypeMismatch                                 -- ^ value and spec type mismatch
   | CustomProblem Text                           -- ^ custom spec error message
   | WrongAtom                                    -- ^ atoms didn't match
+  | WrongText                                    -- ^ specific text didn't match
   deriving Show
 
 -- | Describe outermost shape of a 'PrimValueSpec'
@@ -93,6 +94,7 @@ data Problem p
 -- @since 1.2.0.0
 describeSpec :: PrimValueSpec a -> Text
 describeSpec TextSpec                   = "text"
+describeSpec (SpecificTextSpec a)       = "text \"" <> a <> "\""
 describeSpec NumberSpec                 = "number"
 describeSpec AnyAtomSpec                = "atom"
 describeSpec (AtomSpec a)               = "atom `" <> a <> "`"
@@ -138,6 +140,7 @@ isTypeMismatch :: PrimMismatch p -> Bool
 isTypeMismatch (PrimMismatch _ prob) =
   case prob of
     WrongAtom                                -> True
+    WrongText                                -> True
     TypeMismatch                             -> True
     NestedProblem (ValueSpecMismatch _ _ xs) -> all isTypeMismatch xs
     _                                        -> False
@@ -201,6 +204,9 @@ prettyProblem p =
   case p of
     TypeMismatch ->
       ( text "- type mismatch"
+      , empty)
+    WrongText ->
+      ( text "- wrong text"
       , empty)
     WrongAtom ->
       ( text "- wrong atom"

--- a/src/Config/Schema/Spec.hs
+++ b/src/Config/Schema/Spec.hs
@@ -45,6 +45,7 @@ module Config.Schema.Spec
   -- ** Text specifications
   -- $text
   , textSpec
+  , textSpec'
   , stringSpec
 
   -- ** Atom specifications
@@ -348,6 +349,10 @@ trueOrFalseSpec = True <$ atomSpec "true" <!> False <$ atomSpec "false"
 -- @since 1.2.0.0
 textSpec :: ValueSpec Text
 textSpec = primValueSpec TextSpec
+
+-- | Specification for matching a specific text literal
+textSpec' :: Text -> ValueSpec ()
+textSpec' = primValueSpec . SpecificTextSpec
 
 -- | Specification for matching any text as a 'String'
 stringSpec :: ValueSpec String

--- a/src/Config/Schema/Types.hs
+++ b/src/Config/Schema/Types.hs
@@ -59,6 +59,8 @@ data PrimValueSpec :: * -> * where
   -- | Matches any string literal
   TextSpec :: PrimValueSpec Text
 
+  SpecificTextSpec :: Text -> PrimValueSpec ()
+
   -- | Matches numbers
   NumberSpec :: PrimValueSpec Number
 
@@ -80,7 +82,7 @@ data PrimValueSpec :: * -> * where
 
   -- | Documentation text and underlying specification. This specification
   -- will match values where the underlying specification returns a
-  -- 'Right' value. Otherwise a 'Left' should contain a short failure 
+  -- 'Right' value. Otherwise a 'Left' should contain a short failure
   -- explanation.
   CustomSpec :: Text -> ValueSpec (Either Text a) -> PrimValueSpec a
 

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -65,6 +65,9 @@ main = sequenceA_
   , test (atomSpec "testing-1-2-3") ()
     [["testing-1-2-3"]]
 
+  , test (textSpec' "specific-text") ()
+    [["\"specific-text\""]]
+
   , test (listSpec anySpec) ([]::[Integer])
     [["[]"]
     ,["[ ]"]]


### PR DESCRIPTION
Adds textSpec' which acts similar to atomSpec except it works on texts instead of atoms.

For automatic config generation from nixos we would like to use YAML generators, since recently config-value accepts YAML-style lists as well. However, existing tooling makes it hard to control when to put out strings with or without quotes. Realistically you're forced to always emit atoms or always emit texts.

Using `anyAtom` is too constraining, as not every valid string is a valid atom, but using `textSpec/customSpec` means we lose the ability to enumerate possible values in documentation/diagnostics.

With the pull request you can use `textSpec'` similarly to `atomSpec` while sticking to text. This lets us name specific possible strings that diagnostics/documentation can print out.